### PR TITLE
Dates using forward-slash

### DIFF
--- a/syntaxes/klog.json
+++ b/syntaxes/klog.json
@@ -47,7 +47,7 @@
             "name": "markup.other.duration.positive.klog"
         },
         "record": {
-            "begin": "^(\\d{4}-\\d{2}-\\d{2}|\\d{4}\\\\\\d{2}\\\\\\d{2})(?:\\s+\\((\\d+h\\d+m|\\d+h|\\d+m)!\\))?",
+            "begin": "^(\\d{4}-\\d{2}-\\d{2}|\\d{4}\\/\\d{2}\\/\\d{2})(?:\\s+\\((\\d+h\\d+m|\\d+h|\\d+m)!\\))?",
             "beginCaptures": {
                 "1": {
                     "name": "markup.heading.date.klog"


### PR DESCRIPTION
Fix dates using format `YYYY/MM/DD` being properly recognized.

Closes #3.