### PR TITLE
Remove invalid highlighting

### DIFF
--- a/syntaxes/klog.json
+++ b/syntaxes/klog.json
@@ -89,15 +89,6 @@
                     "include": "#summary-under-date"
                 },
                 {
-                    "name": "invalid.illegal.summary.after-date.whitespace-prefix.klog",
-                    "match": "(?<=^ ).(.*$)",
-                    "captures": {
-                        "1": {
-                            "name": "string.unquoted.summary.after-date.klo"
-                        }
-                    }
-                },
-                {
                     "begin": "^(?:\t| {2,4})",
                     "end": "$",
                     "patterns": [
@@ -112,14 +103,6 @@
                         },
                         {
                             "include": "#summary-behind-entry"
-                        },
-                        {
-                            "match": "\\G(?<!\\S)(\\p{L}*)(?:\\s|$)",
-                            "captures": {
-                                "1": {
-                                    "name": "invalid.illegal.missing-spacing-after-entry.klog"
-                                }
-                            }
                         }
                     ]
                 }


### PR DESCRIPTION
Syntax highlighting is inconsistent, where it would identify some invalid scenarios, but not all.

With the introduction with the LSP in version v1.1, I firmly believe the syntax rules can be removed.

(Some time in the future I would want a `klog` binary to be downloaded automatically, removing the need to manually enable and specify a path. However, that is another issue)