### PR TITLE
Add default language file icons.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,11 @@
                 ],
                 "extensions": [
                     ".klg"
-                ]
+				],
+				"icon": {
+					"dark": "./resource/klog-white.svg",
+					"light": "./resource/klog-black.svg"
+				}
             }
         ],
         "grammars": [

--- a/resource/klog-black.svg
+++ b/resource/klog-black.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="512px" height="512px" viewBox="-73 -50 512 512" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
+ <g id="New-Group">
+  <path id="Path" d="M258 360 C242.814 214.513 160.631 201.81 160.631 201.81" fill="none" stroke="#000000" stroke-width="33" stroke-opacity="1" stroke-linejoin="round" stroke-linecap="round"/>
+  <path id="Path-1" d="M75 52 L291 52" fill="none" stroke="#000000" stroke-width="33" stroke-opacity="1" stroke-linejoin="round" stroke-linecap="round"/>
+  <path id="Path-copy" d="M75 360 L291 360" fill="none" stroke="#000000" stroke-width="33" stroke-opacity="1" stroke-linejoin="round" stroke-linecap="round"/>
+  <path id="Path-2" d="M108 211 C108 211 227.383 209.339 258 52" fill="none" stroke="#000000" stroke-width="33" stroke-opacity="1" stroke-linejoin="round" stroke-linecap="round"/>
+  <path id="Path-3" d="M108 360 L108 52" fill="none" stroke="#000000" stroke-width="33" stroke-opacity="1" stroke-linejoin="round" stroke-linecap="round"/>
+ </g>
+</svg>

--- a/resource/klog-white.svg
+++ b/resource/klog-white.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="512px" height="512px" viewBox="-73 -50 512 512" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
+ <g id="New-Group">
+  <path id="Path" d="M258 360 C242.814 214.513 160.631 201.81 160.631 201.81" fill="none" stroke="#ffffff" stroke-width="33" stroke-opacity="1" stroke-linejoin="round" stroke-linecap="round"/>
+  <path id="Path-1" d="M75 52 L291 52" fill="none" stroke="#ffffff" stroke-width="33" stroke-opacity="1" stroke-linejoin="round" stroke-linecap="round"/>
+  <path id="Path-copy" d="M75 360 L291 360" fill="none" stroke="#ffffff" stroke-width="33" stroke-opacity="1" stroke-linejoin="round" stroke-linecap="round"/>
+  <path id="Path-2" d="M108 211 C108 211 227.383 209.339 258 52" fill="none" stroke="#ffffff" stroke-width="33" stroke-opacity="1" stroke-linejoin="round" stroke-linecap="round"/>
+  <path id="Path-3" d="M108 360 L108 52" fill="none" stroke="#ffffff" stroke-width="33" stroke-opacity="1" stroke-linejoin="round" stroke-linecap="round"/>
+ </g>
+</svg>


### PR DESCRIPTION
This addresses issue #11, using newly available configuration options for extensions to contribute language file type icons:

https://code.visualstudio.com/api/extension-guides/file-icon-theme#language-default-icons

The SVG icons used were downloaded from https://klog.jotaen.net/logo/ on 2025-06-26, with the only modification being the viewBox, width, and height properties, in order to give the icons square dimensions, plus a bit more padding.